### PR TITLE
Add ability to test framework setup in Debugger.

### DIFF
--- a/dist/tags/framework/debugger.html
+++ b/dist/tags/framework/debugger.html
@@ -92,7 +92,11 @@
   height: 32px;
 }
 
-.__tagsmith_debugger_close {
+.__tagsmith_debugger_actions {
+  display: flex;
+}
+
+.__tagsmith_debugger_action_item {
   font-family: Material Symbols Outlined;
   font-size: 18px;
   text-align: center;
@@ -103,8 +107,41 @@
   cursor: pointer;
 }
 
-.__tagsmith_debugger_close:hover {
+.__tagsmith_debugger_action_item:hover {
   background: #DADCE0;
+}
+
+.__tagsmith_debugger_more {
+  position: relative;
+}
+
+.__tagsmith_debugger_menu {
+  display: none;
+  position: absolute;
+  right: 0;
+  top: 40px;
+  overflow: hidden;
+  background: #FFF;
+  border-radius: 8px;
+  box-shadow:
+    rgba(0, 0, 0, 0.2) 0px 3px 5px -1px,
+    rgba(0, 0, 0, 0.14) 0px 5px 8px 0px,
+    rgba(0, 0, 0, 0.12) 0px 1px 14px 0px;
+}
+
+.__tagsmith_debugger_more:focus > .__tagsmith_debugger_menu {
+  display: block;
+}
+
+.__tagsmith_debugger_menu_item {
+  padding: 6px 12px;
+  font-weight: normal;
+  cursor: pointer;
+  white-space: nowrap;
+}
+
+.__tagsmith_debugger_menu_item:hover {
+  background: #FEF7E0;
 }
 
 .__tagsmith_debugger_body {
@@ -250,7 +287,15 @@
       <div class="__tagsmith_debugger_header">
         <div class="__tagsmith_debugger_icon"></div>
         Tagsmith Debugger
-        <div class="__tagsmith_debugger_close">close</div>
+        <div class="__tagsmith_debugger_actions">
+          <div tabindex="1" class="__tagsmith_debugger_more">
+            <div class="__tagsmith_debugger_action_item">more_horiz</div>
+            <div class="__tagsmith_debugger_menu">
+              <div id="__tagsmith_debugger_test_setup" class="__tagsmith_debugger_menu_item">Test setup</div>
+            </div>
+          </div>
+          <div class="__tagsmith_debugger_action_item __tagsmith_debugger_close">close</div>
+        </div>
       </div>
       <div class="__tagsmith_debugger_body">
         <div>
@@ -407,7 +452,32 @@
   var $root = document.getElementById('__tagsmith_debugger');
   var $open = $root.querySelector('.__tagsmith_debugger_open');
   var $container = $root.querySelector('.__tagsmith_debugger_container');
+  var $testSetup = $root.querySelector('#__tagsmith_debugger_test_setup');
   var $close = $root.querySelector('.__tagsmith_debugger_close');
+
+  var testSetupLogger;
+
+  /**
+   * Test framework setup.
+   */
+  var testSetup = function() {
+    var userVariant = w[o].userVariant();
+
+    if (!testSetupLogger) {
+      testSetupLogger = w[o].getLogger('debugger', userVariant);
+    }
+
+    if (testSetupLogger) {
+      var eventName = 'testEventName';
+      var eventValue = 'testEventValue';
+      testSetupLogger(eventName, eventValue);
+      alert('Event sent with name: ' + eventName + ', value: ' + eventValue);
+    } else {
+      alert('Can\'t get logger for debugger.');
+    }
+  };
+
+  $testSetup.addEventListener('click', testSetup);
 
   /**
    * Refresh all UI elements.

--- a/spec/tags/framework/debugger.spec.ts
+++ b/spec/tags/framework/debugger.spec.ts
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2023 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import * as browser from '../../helpers/browser';
+
+describe('Debugger', () => {
+  beforeEach(browser.launch);
+  afterEach(browser.close);
+
+  it('should not log if Logger not presents', async () => {
+    const page = await browser.generatePage({
+      frameworks: ['debugger'],
+      forceAbFactor: 0.07, // test1_exp1
+    });
+
+    page.once('dialog', async (dialog) => {
+      expect( dialog.message()).toContain('Can\'t get logger');
+      await dialog.dismiss();
+    });
+
+    await page.click('.__tagsmith_debugger_open');
+    await page.click('.__tagsmith_debugger_more');
+    await page.click('#__tagsmith_debugger_test_setup');
+
+    const dataLayer = await page.evaluate(`window.dataLayer`);
+
+    expect(dataLayer).toBeUndefined();
+  });
+
+  it(`should log into dataLayer`, async () => {
+    const page = await browser.generatePage({
+      frameworks: ['logger', 'debugger'],
+      forceAbFactor: 0.07, // test1_exp1
+    });
+
+    page.once('dialog', async (dialog) => {
+      expect( dialog.message()).toContain('Event sent');
+      await dialog.dismiss();
+    });
+
+    await page.click('.__tagsmith_debugger_open');
+    await page.click('.__tagsmith_debugger_more');
+    await page.click('#__tagsmith_debugger_test_setup');
+
+    const dataLayer = await page.evaluate(`window.dataLayer`);
+
+    expect(dataLayer).toEqual([
+      {
+        event: 'tagsmith_event',
+        userVariant: 'test1_exp1',
+        id: 'debugger.testEventName',
+        value: 'testEventValue',
+      },
+    ]);
+  });
+});

--- a/src/tags/framework/debugger/script.js
+++ b/src/tags/framework/debugger/script.js
@@ -144,7 +144,32 @@
   var $root = document.getElementById('__tagsmith_debugger');
   var $open = $root.querySelector('.__tagsmith_debugger_open');
   var $container = $root.querySelector('.__tagsmith_debugger_container');
+  var $testSetup = $root.querySelector('#__tagsmith_debugger_test_setup');
   var $close = $root.querySelector('.__tagsmith_debugger_close');
+
+  var testSetupLogger;
+
+  /**
+   * Test framework setup.
+   */
+  var testSetup = function() {
+    var userVariant = w[o].userVariant();
+
+    if (!testSetupLogger) {
+      testSetupLogger = w[o].getLogger('debugger', userVariant);
+    }
+
+    if (testSetupLogger) {
+      var eventName = 'testEventName';
+      var eventValue = 'testEventValue';
+      testSetupLogger(eventName, eventValue);
+      alert('Event sent with name: ' + eventName + ', value: ' + eventValue);
+    } else {
+      alert('Can\'t get logger for debugger.');
+    }
+  };
+
+  $testSetup.addEventListener('click', testSetup);
 
   /**
    * Refresh all UI elements.

--- a/src/tags/framework/debugger/style.css
+++ b/src/tags/framework/debugger/style.css
@@ -89,7 +89,11 @@
   height: 32px;
 }
 
-.__tagsmith_debugger_close {
+.__tagsmith_debugger_actions {
+  display: flex;
+}
+
+.__tagsmith_debugger_action_item {
   font-family: Material Symbols Outlined;
   font-size: 18px;
   text-align: center;
@@ -100,8 +104,41 @@
   cursor: pointer;
 }
 
-.__tagsmith_debugger_close:hover {
+.__tagsmith_debugger_action_item:hover {
   background: #DADCE0;
+}
+
+.__tagsmith_debugger_more {
+  position: relative;
+}
+
+.__tagsmith_debugger_menu {
+  display: none;
+  position: absolute;
+  right: 0;
+  top: 40px;
+  overflow: hidden;
+  background: #FFF;
+  border-radius: 8px;
+  box-shadow:
+    rgba(0, 0, 0, 0.2) 0px 3px 5px -1px,
+    rgba(0, 0, 0, 0.14) 0px 5px 8px 0px,
+    rgba(0, 0, 0, 0.12) 0px 1px 14px 0px;
+}
+
+.__tagsmith_debugger_more:focus > .__tagsmith_debugger_menu {
+  display: block;
+}
+
+.__tagsmith_debugger_menu_item {
+  padding: 6px 12px;
+  font-weight: normal;
+  cursor: pointer;
+  white-space: nowrap;
+}
+
+.__tagsmith_debugger_menu_item:hover {
+  background: #FEF7E0;
 }
 
 .__tagsmith_debugger_body {

--- a/src/tags/framework/debugger/tag.html
+++ b/src/tags/framework/debugger/tag.html
@@ -24,7 +24,15 @@
       <div class="__tagsmith_debugger_header">
         <div class="__tagsmith_debugger_icon"></div>
         Tagsmith Debugger
-        <div class="__tagsmith_debugger_close">close</div>
+        <div class="__tagsmith_debugger_actions">
+          <div tabindex="1" class="__tagsmith_debugger_more">
+            <div class="__tagsmith_debugger_action_item">more_horiz</div>
+            <div class="__tagsmith_debugger_menu">
+              <div id="__tagsmith_debugger_test_setup" class="__tagsmith_debugger_menu_item">Test setup</div>
+            </div>
+          </div>
+          <div class="__tagsmith_debugger_action_item __tagsmith_debugger_close">close</div>
+        </div>
       </div>
       <div class="__tagsmith_debugger_body">
         <div>


### PR DESCRIPTION
Added a "Test setup" menu in Debugger. This will send a test event through `getLogger`.
Publisher can then check if the event appears in GA4 Report, and if yes, we can assume the followings are correctly set up in Tag Manager.

- Tags:
  - Tagsmith - Event
  - Tagsmith - Logger
- Triggers
  - Tagsmith - Event
- Variables
  - tagsmith.event.id
  - tagsmith.event.userVariant
  - tagsmith.event.value

UI:
![image](https://github.com/google-marketing-solutions/tagsmith/assets/2175401/169b591b-a147-45e7-b1ab-299e8d4c5119)